### PR TITLE
Fix frontend start after npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+**/node_modules/
+package-lock.json

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://super-spork-97xqqprg4pp9h76p9-3000.app.github.dev
+VITE_API_BASE_URL=http://localhost:3000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,8 @@
     "axios": "^1.7.0",
     "react-router-dom": "^6.23.0"
   },
-  "devDependencies": {
-    "@vitejs/plugin-react": "^4.5.1"
-
+    "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.1",
     "vite": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- fix `package.json` JSON format for the React frontend
- set API base URL to localhost
- add `.gitignore`

## Testing
- `npm run dev` in `backend`
- `nohup npm run dev -- --host 0.0.0.0` in `frontend`
- `curl -I http://localhost:5173`
- `curl -s http://localhost:3000/api/candidates`


------
https://chatgpt.com/codex/tasks/task_e_684165ebf6d4832d82bb1107c65982f4